### PR TITLE
Convert System.Slice.Core.dll to a netmodule

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,4 +1,4 @@
 mkdir bin
-ilasm /dll /debug src\PtrUtils.il /out:bin\System.Slice.Core.dll
-csc /t:library /debug /unsafe /o+ /r:bin\System.Slice.Core.dll /out:bin\System.Slice.dll src\*.cs
+ilasm /dll src\PtrUtils.il /out:bin\System.Slice.netmodule
+csc /t:library /debug /unsafe /o+ /addmodule:bin\System.Slice.netmodule /out:bin\System.Slice.dll src\*.cs
 csc /unsafe /r:bin\System.Slice.dll /out:bin\System.Slice.Test.exe tests\*.cs

--- a/build.cmd
+++ b/build.cmd
@@ -1,5 +1,4 @@
 mkdir bin
 ilasm /dll /debug src\PtrUtils.il /out:bin\System.Slice.Core.dll
-csc /t:library /debug /unsafe /o+ src\*.cs /r:bin\System.Slice.Core.dll /out:bin\System.Slice.dll
-csc /unsafe tests\*.cs /r:bin\System.Slice.dll /out:bin\System.Slice.Test.exe
-
+csc /t:library /debug /unsafe /o+ /r:bin\System.Slice.Core.dll /out:bin\System.Slice.dll src\*.cs
+csc /unsafe /r:bin\System.Slice.dll /out:bin\System.Slice.Test.exe tests\*.cs

--- a/src/PtrUtils.il
+++ b/src/PtrUtils.il
@@ -12,17 +12,13 @@
   .ver 4:0:0:0
 }
 
-.assembly System.Slice.Core
-{
-}
-
 .namespace System
 {
     /// <summary>
     /// A collection of unsafe helper methods that we cannot implement in C#.
     /// NOTE: these can be used for VeryBadThings(tm), so tread with care...
     /// </summary>
-    .class public auto ansi sealed beforefieldinit PtrUtils
+    .class private auto ansi sealed beforefieldinit PtrUtils
         extends [mscorlib]System.Object
     {
         // WARNING:


### PR DESCRIPTION
This makes `PtrUtils` an internal implementation detail of `System.Slice.dll`, instead of being publicly exposed.

Additionally, on my machine, the tests run twice as fast after this change.

### Two assemblies

```
Run TestPerfLoop...
    - ints : 00:00:00.0486338
    - slice: 00:00:00.6664156
    - success (00:00:00.7170923)
Success! (00:00:00.8482107)
```

### Netmodule (this PR)

```
Run TestPerfLoop...
    - ints : 00:00:00.0490365
    - slice: 00:00:00.2535337
    - success (00:00:00.3047157)
Success! (00:00:00.4329764)
```