### PR TITLE
improving for loop time

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,5 +1,5 @@
 mkdir bin
 ilasm /dll src\PtrUtils.il /out:bin\System.Slice.netmodule
 csc /t:library /debug:pdbonly /unsafe /o+ /addmodule:bin\System.Slice.netmodule /out:bin\System.Slice.dll src\*.cs
-csc /debug:pdbonly /unsafe /r:bin\System.Slice.dll /out:bin\System.Slice.Test.exe tests\*.cs
+csc /debug:pdbonly /unsafe /o+ /r:bin\System.Slice.dll /out:bin\System.Slice.Test.exe tests\*.cs
 

--- a/src/Contract.cs
+++ b/src/Contract.cs
@@ -34,7 +34,9 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void RequiresInRange(int start, int length)
         {
-            if (!(start >= 0 && start < length)) {
+            // use unsigned int to reduce range check by one ( >= 0 )
+            if ((uint)start >= (uint)length)
+            {
                 throw new ArgumentOutOfRangeException();
             }
         }

--- a/src/Contract.cs
+++ b/src/Contract.cs
@@ -35,15 +35,14 @@ namespace System
         public static void RequiresInRange(int start, int length)
         {
             // use unsigned int to reduce range check by one ( >= 0 )
-            if ((uint)start >= (uint)length)
-            {
+            if ((uint)start >= (uint)length) {
                 throw new ArgumentOutOfRangeException();
             }
         }
 
         public static void RequiresInInclusiveRange(int start, int length)
         {
-            if (!(start >= 0 && start <= length)) {
+            if ((uint)start > (uint)length) {
                 throw new ArgumentOutOfRangeException();
             }
         }

--- a/src/Contract.cs
+++ b/src/Contract.cs
@@ -34,16 +34,24 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void RequiresInRange(int start, int length)
         {
-            // use unsigned int to reduce range check by one ( >= 0 )
-            if ((uint)start >= (uint)length) {
-                throw new ArgumentOutOfRangeException();
+            // explicit unchecked block is used in order to avoid OverflowException when casting 
+            // negative int to unsigned int when the code is compiled with /checked option
+            unchecked 
+            {
+                // use unsigned int to reduce range check by one ( >= 0 )
+                if ((uint)start >= (uint)length) {
+                    throw new ArgumentOutOfRangeException();
+                }
             }
         }
 
         public static void RequiresInInclusiveRange(int start, int length)
         {
-            if ((uint)start > (uint)length) {
-                throw new ArgumentOutOfRangeException();
+            unchecked
+            {
+                if ((uint)start > (uint)length) {
+                    throw new ArgumentOutOfRangeException();
+                }
             }
         }
 

--- a/src/Slice.cs
+++ b/src/Slice.cs
@@ -8,6 +8,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace System
 {
@@ -151,6 +152,7 @@ namespace System
         /// </exception>
         public T this[int index]
         {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)] // it makes enumeration via IEnumerable faster
             get {
                 Contract.RequiresInRange(index, Length);
                 return PtrUtils.Get<T>(

--- a/src/Slice.cs
+++ b/src/Slice.cs
@@ -17,7 +17,7 @@ namespace System
     /// to regular accesses and is a struct so that creation and subslicing do
     /// not require additional allocations.  It is type- and memory-safe.
     /// </summary>
-    public struct Slice<T> : IEnumerable<T>
+    public partial struct Slice<T> : IEnumerable<T>
     {
         /// <summary>A managed array/string; or null for native ptrs.</summary>
         readonly object  m_object;
@@ -230,66 +230,6 @@ namespace System
             return Object == other.Object &&
                 Offset == other.Offset && Length == other.Length;
         }
-
-        /// <summary>
-        /// Returns an enumerator over the Slice's entire contents.
-        /// </summary>
-        public Enumerator GetEnumerator()
-        {
-            return new Enumerator(this);
-        }
-
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
-
-        IEnumerator<T> IEnumerable<T>.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
-
-        /// <summary>
-        /// A struct-based enumerator, to make fast enumerations possible.
-        /// This isn't designed for direct use, instead see GetEnumerator.
-        /// </summary>
-        public struct Enumerator : IEnumerator<T>
-        {
-            Slice<T> m_slice;    // The slice being enumerated.
-            int      m_position; // The current position.
-
-            public Enumerator(Slice<T> slice)
-            {
-                m_slice = slice;
-                m_position = -1;
-            }
-
-            public T Current
-            {
-                get { return m_slice[m_position]; }
-            }
-
-            object IEnumerator.Current
-            {
-                get { return Current; }
-            }
-
-            public void Dispose()
-            {
-                m_slice = default(Slice<T>);
-                m_position = -1;
-            }
-
-            public bool MoveNext()
-            {
-                return ++m_position < m_slice.Length;
-            }
-
-            public void Reset()
-            {
-                m_position = -1;
-            }
-        }        
     }
 }
 

--- a/src/Slice.cs
+++ b/src/Slice.cs
@@ -232,6 +232,18 @@ namespace System
             return Object == other.Object &&
                 Offset == other.Offset && Length == other.Length;
         }
+
+        /// <summary>
+        /// Returns item from given index without the boundaries check
+        /// use only in places where moving outside the boundaries is impossible
+        /// gain: performance: no boundaries check (single operation) 
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal T GetItemWithoutBoundariesCheck(int index)
+        {
+            return PtrUtils.Get<T>(
+                    m_object, m_offset + (index * PtrUtils.SizeOf<T>()));
+        }
     }
 }
 

--- a/src/SliceEnumerators.cs
+++ b/src/SliceEnumerators.cs
@@ -114,7 +114,13 @@ namespace System
 
             public bool MoveNext()
             {
-                return ++m_position < m_slice.Length;
+                int nextItemIndex = m_position + 1;
+                if (nextItemIndex < m_slice.Length)
+                {
+                    m_position = nextItemIndex;
+                    return true;
+                }
+                return false;
             }
 
             public void Reset()

--- a/src/SliceEnumerators.cs
+++ b/src/SliceEnumerators.cs
@@ -1,0 +1,128 @@
+//===--- SliceEnumerators.cs ---------------------------------------------------------===//
+//
+// Copyright (c) 2015 Joe Duffy. All rights reserved.
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+//===----------------------------------------------------------------------===//
+
+using System.Collections;
+using System.Collections.Generic;
+
+namespace System
+{
+    /// <summary>
+    /// this file contains all logic responsible for IEnumerable implementation
+    /// these are mostly some tricks so they are kept is separate file
+    /// </summary>
+    public partial struct Slice<T>
+    {
+        /// <summary>
+        /// compiler is using this method in every occurence of foreach
+        /// CONDITIONS:
+        ///     1. Slice is not used via the IEnumerable interface
+        ///     2. Slice type has public method  
+        ///         "GetEnumerator that takes no parameters and returns a type that has two members:
+        ///         a) a method MoveNext that takes no parameters and return a Boolean, and 
+        ///         b) a property Current with a getter that returns an Object"
+        ///         source: http://blogs.msdn.com/b/kcwalina/archive/2007/07/18/ducknotation.aspx
+        /// GAINS:
+        ///     1. does not call interface members on structures which is expensive
+        ///     2. does not put it into try/finally block with Dispose in the finally
+        /// </summary>
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(this);
+        }
+
+        /// <summary>
+        /// please use the generic version if possible
+        /// </summary>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return new EnumeratorObject(this);
+        }
+
+        /// <summary>
+        /// compiler is using this method in every occurence of foreach
+        /// where Slice IS accessed via the <see cref="IEnumerable{T}"/> interface
+        /// </summary>
+        IEnumerator<T> IEnumerable<T>.GetEnumerator()
+        {
+            return new EnumeratorObject(this);
+        }
+
+        /// <summary>
+        /// A struct-based enumerator, to make fast enumerations possible.
+        /// This isn't designed for direct use, instead see GetEnumerator.
+        /// Using structure avoids expensive heap allocations
+        /// </summary>
+        public struct Enumerator
+        {
+            Slice<T> m_slice;    // The slice being enumerated.
+            int      m_position; // The current position.
+
+            internal Enumerator(Slice<T> slice)
+            {
+                m_slice = slice;
+                m_position = -1;
+            }
+
+            public T Current
+            {
+                get { return m_slice[m_position]; }
+            }
+
+            public bool MoveNext()
+            {
+                return ++m_position < m_slice.Length;
+            }
+        }
+
+        /// <summary>
+        /// enumerator that implements <see cref="IEnumerator{T}"/> pattern (including <see cref="IDisposable"/>).
+        /// it is used by LINQ and foreach when Slice is accessed via <see cref="IEnumerable{T}"/>
+        /// it is reference type to avoid boxing when calling interface methods on stuctures
+        /// </summary>
+        private class EnumeratorObject : IEnumerator<T>
+        {
+            Slice<T> m_slice;    // The slice being enumerated.
+            int      m_position; // The current position.
+
+            public EnumeratorObject(Slice<T> slice)
+            {
+                m_slice = slice;
+                m_position = -1;
+            }
+
+            public T Current
+            {
+                get { return m_slice[m_position]; }
+            }
+
+            object IEnumerator.Current
+            {
+                get { return Current; }
+            }
+
+            public void Dispose()
+            {
+                // we don't have any managed resources here so we do not Dispose anything here
+                // we also don't need to set m_slice to null because when this instance becames garbage
+                // the reference stored in this field is also going to became GC-reachable (garbage)
+            }
+
+            public bool MoveNext()
+            {
+                return ++m_position < m_slice.Length;
+            }
+
+            public void Reset()
+            {
+                m_position = -1;
+            }
+        }
+    }
+}
+
+

--- a/tests/Harness.cs
+++ b/tests/Harness.cs
@@ -25,6 +25,9 @@ class Program
         else {
             Console.WriteLine("{0} Failures ({1})", t.Failures, sw.Elapsed);
         }
+        Console.WriteLine("==========");
+        Console.WriteLine("Performance Tests");
+        t.RunTests(new PerformanceTests());
     }
 }
 

--- a/tests/Harness.cs
+++ b/tests/Harness.cs
@@ -107,7 +107,7 @@ class Tester
         return Success;
     }
 
-    public void CleanUpMemory()
+    public static void CleanUpMemory()
     {
         GC.Collect();
         GC.WaitForPendingFinalizers();

--- a/tests/Harness.cs
+++ b/tests/Harness.cs
@@ -59,6 +59,20 @@ class Tester
         Assert(x.Equals(y), String.Format("{0} != {1}", x, y));
     }
 
+    public void Throws<TException>(Action command)
+        where TException : Exception
+    {
+        try {
+            command.Invoke();
+        }
+        catch (TException) {
+            return;
+        }
+
+        m_failures++;
+        Console.WriteLine("    # assertion failed, command did not throw");
+    }
+
     public bool RunTests(object tests)
     {
         // Run all methods that match the pattern 'bool Test*(Tester t)'

--- a/tests/PerformanceTests.cs
+++ b/tests/PerformanceTests.cs
@@ -172,13 +172,12 @@ class PerformanceTests
         var stopwatch = System.Diagnostics.Stopwatch.StartNew();
 
         int sum = 0;
-
         for (int i = 0; i < ElementsCount; i++) {
             sum += test.Invoke(data);;
         }
 
         stopwatch.Stop();
-        Console.WriteLine("    - {0}:  {1}", new string(typeof(T).Name.Take(5).ToArray()), stopwatch.Elapsed);
+        Console.WriteLine("    - {0}:  {1}", new string((typeof(T).Name + "  ").Take(7).ToArray()), stopwatch.Elapsed);
         return sum;
     }
 

--- a/tests/PerformanceTests.cs
+++ b/tests/PerformanceTests.cs
@@ -1,0 +1,182 @@
+//===--- PerformanceTests.cs ---------------------------------------------------------===//
+//
+// Copyright (c) 2015 Joe Duffy. All rights reserved.
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+//===----------------------------------------------------------------------===//
+
+using System;
+using System.Linq;
+
+class PerformanceTests
+{
+    /// <summary>
+    /// the JIT compiler eliminates bounds check for some standard loops i.e. (int j = 0; j &lt; array.Length; j++) { sum += array[j] }
+    /// the purpose of this test is to show how big the difference is because of that
+    /// and hopefully in the future prove that we gained similar performance
+    /// </summary>
+    public bool TestPerfOfStandardBoundariesForLoop(Tester tester)
+    {
+        const int elementsCount = 10000;
+        var array = GenerateRandomNumbers(elementsCount);
+
+        tester.CleanUpMemory();
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        int arraySum = 0;
+        for (int i = 0; i < elementsCount; i++) {
+            for (int j = 0; j < array.Length; j++) {
+                arraySum += array[j];
+            }
+        }
+        sw.Stop();
+        Console.WriteLine("    - array of ints: {0}", sw.Elapsed);
+
+        tester.CleanUpMemory();
+
+        var slice = array.Slice();
+        sw.Restart();
+        int sliceSum = 0;
+        for (int i = 0; i < elementsCount; i++) {
+            for (int j = 0; j < slice.Length; j++) {
+                sliceSum += slice[j];
+            }
+        }
+        sw.Stop();
+        Console.WriteLine("    - slice of ints: {0}", sw.Elapsed);
+
+        tester.CleanUpMemory();
+
+        var list = array.ToList();
+        sw.Restart();
+        int listSum = 0;
+        for (int i = 0; i < elementsCount; i++) {
+            for (int j = 0; j < list.Count; j++) {
+                listSum += list[j];
+            }
+        }
+        sw.Stop();
+        Console.WriteLine("    - list of ints:  {0}", sw.Elapsed);
+
+        tester.AssertEqual(arraySum, sliceSum);
+        tester.AssertEqual(listSum, sliceSum);
+        return true;
+    }
+
+    /// <summary>
+    /// the JIT compiler does not eliminate bounds check for nonstandard loops i.e. (int j = 0; j &lt; array.Length / 2; j++) { sum += array[j + 1] }
+    /// the purpose of this test is to show that Slice is as fast as Array in this case
+    /// </summary>
+    public bool TestPerfOfNonStandardBoundariesForLoop(Tester tester)
+    {
+        const int elementsCount = 10000;
+        var array = GenerateRandomNumbers(elementsCount);
+
+        tester.CleanUpMemory();
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        int arraySum = 0;
+        for (int i = 0; i < elementsCount; i++) {
+            for (int j = 0; j < array.Length / 2; j++) {
+                arraySum += array[j + 1];
+            }
+        }
+        sw.Stop();
+        Console.WriteLine("    - array of ints: {0}", sw.Elapsed);
+
+        tester.CleanUpMemory();
+
+        var slice = array.Slice();
+        sw.Restart();
+        int sliceSum = 0;
+        for (int i = 0; i < elementsCount; i++) {
+            for (int j = 0; j < slice.Length / 2; j++) {
+                sliceSum += slice[j + 1];
+            }
+        }
+        sw.Stop();
+        Console.WriteLine("    - slice of ints: {0}", sw.Elapsed);
+
+        tester.CleanUpMemory();
+
+        var list = array.ToList();
+        sw.Restart();
+        int listSum = 0;
+        for (int i = 0; i < elementsCount; i++) {
+            for (int j = 0; j < list.Count / 2; j++) {
+                listSum += list[j + 1];
+            }
+        }
+        sw.Stop();
+        Console.WriteLine("    - list of ints:  {0}", sw.Elapsed);
+
+        tester.AssertEqual(arraySum, sliceSum);
+        tester.AssertEqual(listSum, sliceSum);
+        return true;
+    }
+
+    /// <summary>
+    /// the compiler optimizes foreach loops for built in collections to be as fast as for loop
+    /// the purpose of this test is to show how big the difference is because of that
+    /// and hopefully in the future prove that we gained similar performance
+    /// </summary>
+    public bool TestPerfOfForEachLoop(Tester tester)
+    {
+        const int elementsCount = 10000;
+        var array = GenerateRandomNumbers(elementsCount);
+
+        tester.CleanUpMemory();
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        int arraySum = 0;
+        for (int i = 0; i < elementsCount; i++) {
+            foreach (int number in array) {
+                arraySum += number;
+            }
+        }
+        sw.Stop();
+        Console.WriteLine("    - array of ints: {0}", sw.Elapsed);
+
+        tester.CleanUpMemory();
+
+        var slice = array.Slice();
+        sw.Restart();
+        int sliceSum = 0;
+        for (int i = 0; i < elementsCount; i++) {
+            foreach (int number in slice) {
+                sliceSum += number;
+            }
+        }
+        sw.Stop();
+        Console.WriteLine("    - slice of ints: {0}", sw.Elapsed);
+
+        tester.CleanUpMemory();
+
+        var list = array.ToList();
+        sw.Restart();
+        int listSum = 0;
+        for (int i = 0; i < elementsCount; i++) {
+            foreach (int number in list) {
+                listSum += number;
+            }
+        }
+        sw.Stop();
+        Console.WriteLine("    - list of ints:  {0}", sw.Elapsed);
+
+        tester.AssertEqual(arraySum, sliceSum);
+        tester.AssertEqual(listSum, sliceSum);
+        return true;
+    }
+
+    private static int[] GenerateRandomNumbers(int count)
+    {
+        var ints = new int[count];
+        var random = new Random(1234);
+        for (int i = 0; i < ints.Length; i++) {
+            ints[i] = random.Next();
+        }
+        return ints;
+    }
+}
+

--- a/tests/Tests.cs
+++ b/tests/Tests.cs
@@ -144,5 +144,19 @@ class Tests
         }
         return true;
     }
+
+    public bool TestRangeCheckAlwaysThrowsArgumentOutOfRangeExceptionForNegativeValues(Tester tester)
+    {
+        var slice = new[] { 0, 1, 2, 3 }.Slice();
+
+        unchecked {
+            tester.Throws<ArgumentOutOfRangeException>(() => { int x = slice[-1]; });
+        }
+        checked {
+            tester.Throws<ArgumentOutOfRangeException>(() => { int x = slice[-1]; });
+        }
+
+        return true;
+    }
 }
 

--- a/tests/Tests.cs
+++ b/tests/Tests.cs
@@ -144,41 +144,5 @@ class Tests
         }
         return true;
     }
-
-    public bool TestPerfLoop(Tester t)
-    {
-        var ints = new int[10000];
-        Random r = new Random(1234);
-        for (int i = 0; i < ints.Length; i++) { ints[i] = r.Next(); }
-
-        t.CleanUpMemory();
-
-        var sw = System.Diagnostics.Stopwatch.StartNew();
-        int x = 0;
-        for (int i = 0; i < 10000; i++) {
-            for (int j = 0; j < ints.Length; j++) {
-                x += ints[i];
-            }
-        }
-        sw.Stop();
-        Console.WriteLine("    - ints : {0}", sw.Elapsed);
-
-        t.CleanUpMemory();
-
-        var slice = ints.Slice();
-        sw.Reset();
-        sw.Start();
-        int y = 0;
-        for (int i = 0; i < 10000; i++) {
-            for (int j = 0; j < slice.Length; j++) {
-                y += slice[i];
-            }
-        }
-        sw.Stop();
-        Console.WriteLine("    - slice: {0}", sw.Elapsed);
-
-        t.AssertEqual(x, y);
-        return true;
-    }
 }
 


### PR DESCRIPTION
First of all I wrote four different performance tests for looping:
1. "TestPerfOfStandardBoundariesForLoop" - a 0 to .Length for loop to show how fast is slice when compared to array and list (in this scenario these collections get help from compiler - boundaries check elimination)
2. "TestPerfOfNonStandardBoundariesForLoop"  - custom range loop so compiler does not help array or list
3. "TestPerfOfForEachLoop" - standard foreach loop, we can see that array gets extra help
4. "TestPerfOfForEachLoopWhenUsedViaInterface" - foreach loop on collections used via IEnumerable<T>

The optimizations I have introduced:
1. Simpler range check by casting index and length to unsigned integers to eliminate index >= 0 check
2. Removing Dispose from struct Enumerator to avoid compiler from putting foreach in try+finally block
3. Introducing new EnumeratorObject class that is created when the collection is being enumerated via the IEnumerable<T> interface. Since IEnumerable<T>.GetEnumerator() returns IEnumerator<T> (interface) it would be costly if this was struct because invoking interface method on structures is expensive
4. Added inlining of indexer getter, which makes the EnumeratorObject inline the indexer method.
5. Added GetItemWithoutBoundariesCheck method, which is used in safe EnumeratorObject,  where Improved MoveNext ensures that it is impossible to move outside boundaries. It eliminates single range check (stadard indexer)
6. Storing slice.Length in private field of the enumerators. Length is now next to current position in memory so due to the data locality we have bigger chances for CPU cache HIT. Gain is from 3% to 13% depending on value/ref type, size and processor architecture

![timings](https://cloud.githubusercontent.com/assets/6011991/8906305/d5d98948-346d-11e5-94cd-a6e5e9392c4f.png)
